### PR TITLE
Escape feed titles and URLs in OPML export

### DIFF
--- a/src/manage/export.ts
+++ b/src/manage/export.ts
@@ -1,5 +1,14 @@
 const link = document.getElementById("download") as HTMLAnchorElement;
 
+function escapeXml(input: string): string {
+	return input
+		.replace("&", "&amp;")
+		.replace("\"", "&quot;")
+		.replace("'", "&apos;")
+		.replace("<", "&lt;")
+		.replace(">", "&gt;");
+}
+
 async function exportFeeds(): Promise<void> {
 	const feeds: Feed[] = (await browser.storage.sync.get({ feeds: [] })).feeds;
 
@@ -7,7 +16,7 @@ async function exportFeeds(): Promise<void> {
 <opml version="1.0">
   <body>
     ${feeds
-		.map(f => `<outline title="${f.name}" xmlUrl="${f.url}" />`)
+		.map(f => `<outline title="${escapeXml(f.name)}" xmlUrl="${escapeXml(f.url)}" />`)
 		.join("\n    ")}
   </body>
 </opml>`;


### PR DESCRIPTION
The export feature was failing to produce valid XML because it did not escape any characters when generating XML. Although most of the characters are uncommon in this situation, ampersands are common in URLs, which caused me to notice this problem.

---

I found your extension a couple of months ago, and it's been very useful! I don't know if you still maintain it, but I have some more changes locally with bug fixes and minor improvements. If you are interested in reviewing and possibly merging them, then I can create some more PRs after this one.